### PR TITLE
Fix PHP warning in SliderProcessor

### DIFF
--- a/Classes/DataProcessing/SliderProcessor.php
+++ b/Classes/DataProcessing/SliderProcessor.php
@@ -67,7 +67,7 @@ class SliderProcessor implements DataProcessorInterface
         $flexformData = $processedData['data']['pi_flexform'];
         if (is_string($flexformData)) {
             $flexformData = $this->flexFormService->convertFlexFormContentToArray($flexformData);
-            if (is_array($flexformData['settings']['js'])) {
+            if (is_array($flexformData['settings']['js'] ?? null)) {
                 ArrayUtility::mergeRecursiveWithOverrule(
                     $settings['parameters'],
                     $flexformData['settings']['js'],


### PR DESCRIPTION
Avoid undefined array key warning if no flexform js setting has been set. This did happen to me after converting from ws_flexslider to ws_slider and upgrading to PHP 8.1.